### PR TITLE
DEV-3050 replace asyncio-nats-client with nats-py

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -67,17 +67,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "asyncio-nats-client"
-version = "0.11.5"
-description = "NATS client for Python Asyncio"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.extras]
-nkeys = ["nkeys"]
-
-[[package]]
 name = "atomicwrites"
 version = "1.4.1"
 description = "Atomic file writes."
@@ -385,6 +374,19 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "nats-py"
+version = "2.4.0"
+description = "NATS client for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+aiohttp = ["aiohttp"]
+fast-parse = ["fast-mail-parser"]
+nkeys = ["nkeys"]
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -641,7 +643,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "7dc7c189e9ab2664edb9de3d23248786bed9c3dc067cf5f5d8387e8f10c0bbd8"
+content-hash = "15b5a97f4000128aa952c4e3d663a623127ea756c4b0c6303d6d67dc8cf025f5"
 
 [metadata.files]
 aiobotocore = [
@@ -748,9 +750,6 @@ aiosignal = [
 async-timeout = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
     {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
-]
-asyncio-nats-client = [
-    {file = "asyncio-nats-client-0.11.5.tar.gz", hash = "sha256:c6a2855a63db68289bb270240670ff30514ba0082a8b4f759b8e9955ac84c575"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
@@ -1130,6 +1129,9 @@ multidict = [
 mypy-extensions = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+nats-py = [
+    {file = "nats-py-2.4.0.tar.gz", hash = "sha256:ae8aa34b2f4006ab7700349d7283323bba7d3e766b71ac2e3cfe5fdc8b888862"},
 ]
 packaging = [
     {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ url = "https://coverahealth.jfrog.io/artifactory/api/pypi/development-pypi/simpl
 [tool.poetry.dependencies]
 python = "^3.9"
 aiohttp = "^3.8.3"
-asyncio-nats-client = "^0.11.5"
 hl7 = "^0.4.5"
 covera-ddtrace = "^0.1.3"
 pydantic = "^1.10.7"
 aiobotocore = "^2.5.0"
 python-json-logger = "^2.0.7"
+nats-py = "^2.4.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "7.1.2"

--- a/src/main/py/hl7_listener/messaging/nats.py
+++ b/src/main/py/hl7_listener/messaging/nats.py
@@ -54,7 +54,6 @@ class NATSMessager(MessagingInterface):
             "subject": msgr_config.settings.NATS_OUTGOING_SUBJECT,
             "payload": to_send,
             "timeout": 10,
-            "cb": None
         }
 
         if msgr_config.settings.PILOT_MODE:

--- a/src/test/py/test_main.py
+++ b/src/test/py/test_main.py
@@ -66,7 +66,6 @@ async def test_pilot(mock_pilot_settings, mocker):
         subject=mock_pilot_settings.NATS_OUTGOING_SUBJECT,
         payload="test message".encode(),
         timeout=10,
-        cb=None,
         headers=PILOT_HEADER
     )
     my_asyncmock.assert_awaited()


### PR DESCRIPTION
To fix this error because asyncio-nats-client does not support headers: 
```
{"asctime": "2023-10-02 16:04:41,724", "levelname": "ERROR", "name": "__main__", "filename": "main.py", "lineno": 74, "dd.service": null, "dd.env": null, "dd.version": null, "dd.trace_id": null, "dd.span_id": null, "message": "HL7LERR007: Unknown error during HL7 receive message processing. peername=('127.0.0.1', 63724)", "exc_info": "Traceback (most recent call last):\n  File \"/Users/sajalgoyal/src/github.com/coverahealth/qcc-gateway-hl7-listener/src/main/py/hl7_listener/main.py\", line 52, in process_received_hl7_messages\n    await messager.send_msg(msg=str(hl7_message))\n  File \"/Users/sajalgoyal/src/github.com/coverahealth/qcc-gateway-hl7-listener/src/main/py/hl7_listener/messaging/nats.py\", line 63, in send_msg\n    send_response = await self.conn.request(**kwargs)\nTypeError: request() got an unexpected keyword argument 'headers'"}
```