### PR TITLE
[DEV-3309] Add hl7 type and trigger to received log

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,9 @@ install:
 test *args:
     poetry run pytest {{args}}
 
+test-coverage *args:
+    poetry run pytest {{args}} --cov-report term-missing --cov=src/main/py/hl7_listener --cov-fail-under=80 src/test/
+
 build artifactory_user artifactory_api_key *args:
     poetry build -f wheel
     docker build {{args}} \

--- a/src/main/py/hl7_listener/utils/logging_codes.py
+++ b/src/main/py/hl7_listener/utils/logging_codes.py
@@ -22,7 +22,7 @@ STARTUP_ENV_VARS = (
     "HL7LLOG001: HL7 Listener started with the follow values from the env:\n%s"
 )
 HL7_MLLP_CONNECTED = "HL7LLOG002: HL7 Listener connection established. peername=%s"
-HL7_MLLP_MSG_RECEIVED = "HL7LLOG003: HL7 Listener received a message."
+HL7_MLLP_MSG_RECEIVED = "HL7LLOG003: HL7 Listener received a message of type: %s"
 HL7_MLLP_DISCONNECTED = "HL7LLOG004: HL7 Listener connection closed. peername=%s"
 HL7_MLLP_RECEIVER_CANCELLED = (
     "HL7LLOG005: HL7 Listener was cancelled. This is not considered an error."

--- a/src/test/py/test_main.py
+++ b/src/test/py/test_main.py
@@ -72,7 +72,7 @@ async def test_pilot(mock_pilot_settings, mocker):
 
 
 @pytest.mark.asyncio
-async def test_processed_received_hl7_messages(mocker):
+async def test_processed_received_hl7_messages(mocker, caplog):
     with open(_hl7_messages_relative_dir + "/adt-a01-sample01.hl7", "r") as file:
         hl7_text = str(file.read())
 
@@ -115,7 +115,6 @@ async def test_processed_received_hl7_messages(mocker):
     mocker.patch.object(mock_hl7_message, "__str__", return_value="not an hl7 message")
     await main.process_received_hl7_messages(asyncmock_reader, asyncmock_writer)
     assert "ack_code='AR'" in str(mock_hl7_message.mock_calls[0])
-
     # Test asyncio.IncompleteReadError.
     # The exception is raised with this scenario.
     #
@@ -141,6 +140,7 @@ async def test_processed_received_hl7_messages(mocker):
     NATSMessager.send_msg.side_effect = Exception("force exception from mock")
     await main.process_received_hl7_messages(asyncmock_reader, asyncmock_writer)
     assert "ack_code='AE'" in str(mock_hl7_message.mock_calls[0])
+    assert "HL7 Listener received a message of type: ADT^A01" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
```json
{
    "asctime": "2023-10-10 18:19:54,531",
    "levelname": "INFO",
    "name": "hl7_listener.main",
    "filename": "main.py",
    "lineno": 53,
    "dd.service": null, "dd.env": null, "dd.version": null, "dd.trace_id": null, "dd.span_id": null,
    "message": "HL7LLOG003: HL7 Listener received a message of type: ADT^A01"
}
```